### PR TITLE
Add NeringaFM

### DIFF
--- a/channels.coffee.md
+++ b/channels.coffee.md
@@ -61,6 +61,13 @@ The soma tag is used to build the stream URL.
                     url: 'http://stream-uk1.radioparadise.com/mp3-128'
                     tags: ['rock']
 
+## Neringa
+		'neringa':
+                    url: 'http://streamer.midiaudio.com:80/ner'
+                    tags: ['lt', 'eclectic', 'chill']
+                    site: 'http://www.neringafm.lt/'
+                    facebook: 'https://www.facebook.com/NeringaFM'
+
 ## News
 
 		'bbcworld':


### PR DESCRIPTION
Alternative Lithuanian radio [NeringaFM](http://www.neringafm.lt/), very eclectic, but leaning towards electronic.

Pretty much ads free (two days listening, didn't hear any). But a friend says they're "mostly ads free" and might play occasional ad once a week or so.