### PR TITLE
Add King Dub Radio stream

### DIFF
--- a/public/channels.js
+++ b/public/channels.js
@@ -215,6 +215,10 @@ const channels = {
   },
 
   // Other Stations
+  'king_dub_radio': {
+    url: 'http://london-dedicated.myautodj.com:8862/stream%20King%20Dub%20Radio',
+    tags: ['other', 'uk', 'london', 'dub', 'reggae']
+  },
   'wassoulou': {
     url: 'https://listen.radionomy.com/radio-wassoulou-internationale',
     tags: ['other', 'mali', 'africa']


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds **King Dub Radio** to the Other Stations section in `public/channels.js`.

- Stream URL: `http://london-dedicated.myautodj.com:8862/stream%20King%20Dub%20Radio` (Shoutcast; verified HEAD returns 200 and `content-type: audio/mpeg`).
- Channel id: `king_dub_radio` (deep link: `#radio/king_dub_radio`; display title is derived as "King Dub Radio").
- Tags: `other` (required for that section), plus `uk`, `london`, `dub`, `reggae`.

No `site` URL was added because a guessed station homepage did not resolve from this environment; artwork can follow from the stream host per existing behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f9b27cd-0c07-448d-b4d4-4498abede585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f9b27cd-0c07-448d-b4d4-4498abede585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

