### PR TITLE
Add King Dub Radio (HTTPS, artwork)

### DIFF
--- a/public/channels.js
+++ b/public/channels.js
@@ -216,8 +216,21 @@ const channels = {
 
   // Other Stations
   'king_dub_radio': {
-    url: 'http://london-dedicated.myautodj.com:8862/stream%20King%20Dub%20Radio',
-    tags: ['other', 'uk', 'london', 'dub', 'reggae']
+    url: 'https://london-dedicated.myautodj.com:8862/stream%20King%20Dub%20Radio',
+    tags: ['other', 'fr', 'france', 'dub', 'reggae'],
+    site: 'https://kingdubfamily.com/',
+    artwork: [
+      {
+        src: 'https://kingdubfamily.com/wp-content/uploads/2025/03/cropped-img_4948.jpg',
+        sizes: '1136x666',
+        type: 'image/jpeg'
+      },
+      {
+        src: 'https://kingdubfamily.com/wp-content/uploads/2021/03/download.png',
+        sizes: '209x241',
+        type: 'image/png'
+      }
+    ]
   },
   'wassoulou': {
     url: 'https://listen.radionomy.com/radio-wassoulou-internationale',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds **King Dub Radio** to Other Stations with HTTPS stream, official site, and artwork.

**Stream:** `https://london-dedicated.myautodj.com:8862/stream%20King%20Dub%20Radio` — Shoutcast; TLS certificate is valid Let's Encrypt for `london-dedicated.myautodj.com`.

**Site:** https://kingdubfamily.com/

**Artwork:** From the official WordPress site — primary `cropped-img_4948.jpg` (1136×666) and `download.png` (209×241, site apple-touch-icon) as fallback.

**Tags:** `other`, `fr`, `france`, `dub`, `reggae`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f9b27cd-0c07-448d-b4d4-4498abede585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f9b27cd-0c07-448d-b4d4-4498abede585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

